### PR TITLE
Introduce power distribution units SNMP agents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 pbr>=1.6 # Apache-2.0
 libvirt-python>=1.2.5 # LGPLv2+
+pysnmp==4.3.2 # BSD

--- a/virtualpdu/pdu/__init__.py
+++ b/virtualpdu/pdu/__init__.py
@@ -1,0 +1,80 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyasn1.type import univ
+
+from virtualpdu.power_states import POWER_OFF
+from virtualpdu.power_states import POWER_ON
+from virtualpdu.power_states import REBOOT
+
+
+class PDUOutlet(object):
+    oid = None
+    default_state = univ.Integer(1)
+
+    def __init__(self, outlet_number, pdu):
+        self.outlet_number = outlet_number
+        self.pdu = pdu
+        self._value = self.default_state
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._value = value
+        self.pdu.outlet_state_changed(self.outlet_number, value)
+
+
+class PDU(object):
+    outlet_count = 1
+    outlet_index_start = 1
+    outlet_class = PDUOutlet
+    power_states = {
+        'on': POWER_ON,
+        'off': POWER_OFF,
+        'reboot': REBOOT
+    }
+
+    core_to_native_power_states = {
+        POWER_ON: 'on',
+        POWER_OFF: 'off',
+        REBOOT: 'reboot'
+    }
+
+    def __init__(self, name, core):
+        self.name = name
+        self.core = core
+
+        self.oids = [
+            self.outlet_class(outlet_number=i + self.outlet_index_start,
+                              pdu=self) for i in range(self.outlet_count)
+            ]
+
+        self.oid_mapping = {}
+        for oid in self.oids:
+            self.oid_mapping[oid.oid] = oid
+
+    def get_core_power_state_from_native(self, native_value):
+        return self.power_states[native_value]
+
+    def get_native_power_state_from_core(self, core_value):
+        return self.core_to_native_power_states[core_value]
+
+    def outlet_state_changed(self, outlet_number, value):
+        self.core.pdu_outlet_state_changed(
+            name=self.name,
+            outlet_number=outlet_number,
+            state=self.get_core_power_state_from_native(value))

--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -1,0 +1,58 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyasn1.type import univ
+
+from virtualpdu.pdu import PDU
+from virtualpdu.pdu import PDUOutlet
+from virtualpdu.power_states import POWER_OFF
+from virtualpdu.power_states import POWER_ON
+from virtualpdu.power_states import REBOOT
+
+rPDU_outlet_control_outlet_command = \
+    (1, 3, 6, 1, 4, 1, 318, 1, 1, 12, 3, 3, 1, 1, 4)
+
+rPDU_power_mappings = {
+    'immediateOn': univ.Integer(1),
+    'immediateOff': univ.Integer(2),
+    'immediateReboot': univ.Integer(3),
+    'delayedOn': univ.Integer(4),
+    'delayedOff': univ.Integer(5),
+    'delayedReboot': univ.Integer(6),
+    'cancelPendingCommand': univ.Integer(7),
+}
+
+
+class APCRackPDUOutlet(PDUOutlet):
+    def __init__(self, outlet_number, pdu):
+        super(APCRackPDUOutlet, self).__init__(outlet_number, pdu)
+        self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
+        self.value = rPDU_power_mappings['immediateOn']
+
+
+class APCRackPDU(PDU):
+    outlet_count = 8
+    outlet_index_start = 1
+    outlet_class = APCRackPDUOutlet
+    power_states = {
+        rPDU_power_mappings['immediateOn']: POWER_ON,
+        rPDU_power_mappings['immediateOff']: POWER_OFF,
+        rPDU_power_mappings['immediateReboot']: REBOOT,
+    }
+
+    core_to_native_power_states = {
+        POWER_ON: rPDU_power_mappings['immediateOn'],
+        POWER_OFF: rPDU_power_mappings['immediateOff'],
+        REBOOT: rPDU_power_mappings['immediateReboot']
+    }

--- a/virtualpdu/pdu/pysnmp_handler.py
+++ b/virtualpdu/pdu/pysnmp_handler.py
@@ -1,0 +1,95 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from pyasn1.codec.ber import decoder
+from pyasn1.codec.ber import encoder
+from pysnmp.proto import api
+
+
+# NOTE(mmitchell): Roughly from implementing-scalar-mib-objects.py in pysnmp.
+# Unfortunately, that file is not part of the pysnmp package and re-use is
+# not possible.
+# pysnmp is distributed under the BSD license.
+
+class SNMPPDUHandler(object):
+    def __init__(self, pdu, community):
+        self.pdu = pdu
+        self.community = community
+        self.logger = logging.getLogger(__name__)
+
+    def message_handler(self, transportDispatcher, transportDomain,
+                        transportAddress, whole_message):
+        while whole_message:
+            message_version = api.decodeMessageVersion(whole_message)
+            if message_version in api.protoModules:
+                protocol = api.protoModules[message_version]
+            else:
+                self.logger.warn(
+                    'Unsupported SNMP version "{}"'.format(message_version))
+                return
+
+            request, whole_message = \
+                decoder.decode(whole_message, asn1Spec=protocol.Message())
+
+            response = protocol.apiMessage.getResponse(request)
+            request_pdus = protocol.apiMessage.getPDU(request)
+            community = protocol.apiMessage.getCommunity(request)
+
+            if not self.valid_community(community):
+                self.logger.warn('Invalid community "{}"'.format(community))
+                return
+
+            response_pdus = protocol.apiMessage.getPDU(response)
+            var_binds = []
+            pending_errors = []
+            error_index = 0
+
+            if request_pdus.isSameTypeWith(protocol.GetRequestPDU()):
+                for oid, val in protocol.apiPDU.getVarBinds(request_pdus):
+                    if oid in self.pdu.oid_mapping:
+                        var_binds.append(
+                            (oid, self.pdu.oid_mapping[oid].value))
+                    else:
+                        return
+            elif request_pdus.isSameTypeWith(protocol.SetRequestPDU()):
+                for oid, val in protocol.apiPDU.getVarBinds(request_pdus):
+                    error_index += 1
+                    if oid in self.pdu.oid_mapping:
+                        self.pdu.oid_mapping[oid].value = val
+                        var_binds.append((oid, val))
+                    else:
+                        var_binds.append((oid, val))
+                        pending_errors.append(
+                            (protocol.apiPDU.setNoSuchInstanceError,
+                             error_index)
+                        )
+            else:
+                protocol.apiPDU.setErrorStatus(response_pdus, 'genErr')
+
+            protocol.apiPDU.setVarBinds(response_pdus, var_binds)
+
+            # Commit possible error indices to response PDU
+            for f, i in pending_errors:
+                f(response_pdus, i)
+
+            transportDispatcher.sendMessage(
+                encoder.encode(response), transportDomain, transportAddress
+            )
+
+        return whole_message
+
+    def valid_community(self, community):
+        return str(community) == self.community

--- a/virtualpdu/power_states.py
+++ b/virtualpdu/power_states.py
@@ -1,0 +1,17 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+POWER_ON = 'POWER_ON'
+POWER_OFF = 'POWER_OFF'
+REBOOT = 'REBOOT'

--- a/virtualpdu/tests/integration/pdu/__init__.py
+++ b/virtualpdu/tests/integration/pdu/__init__.py
@@ -1,0 +1,101 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import threading
+
+from mock import mock
+from pysnmp.carrier.asyncore.dgram import udp
+from pysnmp.carrier.asyncore.dispatch import AsyncoreDispatcher
+from pysnmp.entity.rfc3413.oneliner import cmdgen
+from virtualpdu.pdu.pysnmp_handler import SNMPPDUHandler
+from virtualpdu.tests import base
+from virtualpdu.tests import snmp_client
+
+
+class PDUTestCase(base.TestCase):
+    pdu_class = NotImplementedError
+
+    def setUp(self):
+        super(PDUTestCase, self).setUp()
+
+        self.community = 'test1212'
+        self.core_mock = mock.Mock()
+        self.pdu = self.pdu_class(name='test_pdu', core=self.core_mock)
+        self.pdu_test_harness = SNMPPDUTestHarness(self.pdu,
+                                                   None,
+                                                   None,
+                                                   self.community)
+        self.pdu_test_harness.start()
+
+    def tearDown(self):
+        self.pdu_test_harness.stop()
+        super(PDUTestCase, self).tearDown()
+
+    def snmp_get(self, oid, community=None):
+        s = snmp_client.SnmpClient(cmdgen,
+                                   self.pdu_test_harness.listen_address,
+                                   self.pdu_test_harness.listen_port,
+                                   community or self.community,
+                                   timeout=1,
+                                   retries=1)
+        return s.get_one(oid)
+
+    def snmp_set(self, oid, value, community=None):
+        s = snmp_client.SnmpClient(cmdgen,
+                                   self.pdu_test_harness.listen_address,
+                                   self.pdu_test_harness.listen_port,
+                                   community or self.community,
+                                   timeout=1,
+                                   retries=1)
+
+        return s.set(oid, value)
+
+
+class SNMPPDUTestHarness(threading.Thread):
+    def __init__(self, pdu, listen_address, listen_port, community="public"):
+        super(SNMPPDUTestHarness, self).__init__()
+        self.pdu = pdu
+
+        self.snmp_handler = SNMPPDUHandler(self.pdu, community=community)
+
+        self.listen_address = listen_address or '127.0.0.1'
+        # TODO(mmitchell): bind port "0" and let OS decide of a port.
+        # requires communicating back with parent thread to inform of port
+        # number *OR* open socket and pass it to the thread.
+        self.listen_port = listen_port or random.randint(20000, 30000)
+        self.community = community
+        self.transportDispatcher = AsyncoreDispatcher()
+
+    def run(self):
+        self.transportDispatcher.registerRecvCbFun(
+            self.snmp_handler.message_handler)
+
+        # UDP/IPv4
+        self.transportDispatcher.registerTransport(
+            udp.domainName, udp.UdpSocketTransport().openServerMode(
+                (self.listen_address, self.listen_port))
+        )
+
+        self.transportDispatcher.jobStarted(1)
+
+        try:
+            # Dispatcher will never finish as job#1 never reaches zero
+            self.transportDispatcher.runDispatcher()
+        except Exception:
+            self.transportDispatcher.closeDispatcher()
+            raise
+
+    def stop(self):
+        self.transportDispatcher.jobFinished(1)

--- a/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from virtualpdu.pdu.apc_rackpdu import APCRackPDU
+from virtualpdu.power_states import POWER_OFF
+from virtualpdu.power_states import POWER_ON
+
+from virtualpdu.tests.integration.pdu import PDUTestCase
+
+
+class TestAPCRackPDU(PDUTestCase):
+    pdu_class = APCRackPDU
+
+    def test_all_ports_are_on_by_default(self):
+        enterprises = (1, 3, 6, 1, 4, 1)
+        rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)
+
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (1,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (2,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (3,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (4,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (5,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (6,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (7,)))
+        self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (8,)))
+
+    def test_port_state_can_be_changed(self):
+        enterprises = (1, 3, 6, 1, 4, 1)
+        rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)
+        outlet_1 = enterprises + rPDUControl + (1,)
+
+        native_power_on = self.pdu.get_native_power_state_from_core(POWER_ON)
+        native_power_off = self.pdu.get_native_power_state_from_core(POWER_OFF)
+
+        self.assertEqual(native_power_on,
+                         self.snmp_get(outlet_1))
+
+        self.snmp_set(outlet_1, native_power_off)
+
+        self.assertEqual(native_power_off,
+                         self.snmp_get(outlet_1))

--- a/virtualpdu/tests/integration/pdu/test_pdu.py
+++ b/virtualpdu/tests/integration/pdu/test_pdu.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyasn1.type import univ
+from pysnmp.proto.rfc1905 import NoSuchInstance
+
+from virtualpdu import pdu
+from virtualpdu.tests.integration.pdu import PDUTestCase
+from virtualpdu.tests.snmp_error_indications import RequestTimedOut
+
+enterprises = (1, 3, 6, 1, 4, 1)
+
+
+class TestPDU(PDUTestCase):
+    pdu_class = pdu.PDU
+
+    def test_get_unknown_oid(self):
+        self.assertRaises(RequestTimedOut,
+                          self.snmp_get, enterprises + (42,))
+
+    def test_set_unknown_oid(self):
+        self.assertEqual(NoSuchInstance(),
+                         self.snmp_set(enterprises + (42,), univ.Integer(7)))
+
+    def test_get_valid_oid_wrong_community(self):
+        self.pdu.oid_mapping[enterprises + (88, 1)] = \
+            pdu.PDUOutlet(outlet_number=1, pdu=self.pdu)
+
+        self.assertEqual(1, self.snmp_get(enterprises + (88, 1)))
+
+        self.assertRaises(RequestTimedOut,
+                          self.snmp_get, enterprises + (88, 1),
+                          community='wrong')
+
+    def test_set_wrong_community(self):
+        self.assertRaises(RequestTimedOut,
+                          self.snmp_set, enterprises + (42,), univ.Integer(1),
+                          community='wrong')

--- a/virtualpdu/tests/snmp_client.py
+++ b/virtualpdu/tests/snmp_client.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from virtualpdu.tests import snmp_error_indications
+
+
+class SnmpClient(object):
+    def __init__(self, oneliner_cmdgen, host, port, community, timeout,
+                 retries):
+        self.host = host
+        self.port = port
+        self.community = community
+        self.timeout = timeout
+        self.retries = retries
+
+        cmdgen = oneliner_cmdgen
+        self.command_generator = cmdgen.CommandGenerator()
+        self.community_data = cmdgen.CommunityData(self.community)
+        self.transport = cmdgen.UdpTransportTarget((self.host, self.port),
+                                                   timeout=self.timeout,
+                                                   retries=self.retries)
+
+    def get_one(self, oid):
+        error_indication, error_status, error_index, var_binds = \
+            self.command_generator.getCmd(self.community_data,
+                                          self.transport,
+                                          oid)
+
+        self._handle_error_indication(error_indication)
+
+        name, val = var_binds[0]
+        return val
+
+    def set(self, oid, value):
+        error_indication, error_status, error_index, var_binds = \
+            self.command_generator.setCmd(self.community_data,
+                                          self.transport,
+                                          (oid, value))
+
+        self._handle_error_indication(error_indication)
+
+        name, val = var_binds[0]
+        return val
+
+    def _handle_error_indication(self, error_indication):
+        if error_indication:
+            raise snmp_error_indications.__dict__.get(
+                error_indication.__class__.__name__)()

--- a/virtualpdu/tests/snmp_error_indications.py
+++ b/virtualpdu/tests/snmp_error_indications.py
@@ -1,0 +1,177 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class SNMPErrorIndication(Exception):
+    pass
+
+
+class SNMPMessageProcessingError(SNMPErrorIndication):
+    pass
+
+
+class SerializationError(SNMPMessageProcessingError):
+    pass
+
+
+class DeserializationError(SNMPMessageProcessingError):
+    pass
+
+
+class ParseError(DeserializationError):
+    pass
+
+
+class UnsupportedMsgProcessingModel(SNMPMessageProcessingError):
+    pass
+
+
+class UnknownPDUHandler(SNMPMessageProcessingError):
+    pass
+
+
+class UnsupportedPDUtype(SNMPMessageProcessingError):
+    pass
+
+
+class RequestTimedOut(SNMPMessageProcessingError):
+    pass
+
+
+class EmptyResponse(SNMPMessageProcessingError):
+    pass
+
+
+class NonReportable(SNMPMessageProcessingError):
+    pass
+
+
+class DataMismatch(SNMPMessageProcessingError):
+    pass
+
+
+class EngineIDMismatch(SNMPMessageProcessingError):
+    pass
+
+
+class UnknownEngineID(SNMPMessageProcessingError):
+    pass
+
+
+class TooBig(SNMPMessageProcessingError):
+    pass
+
+
+class LoopTerminated(SNMPMessageProcessingError):
+    pass
+
+
+class InvalidMsg(SNMPMessageProcessingError):
+    pass
+
+
+class SNMPSecurityModuleError(SNMPErrorIndication):
+    pass
+
+
+class UnknownCommunityName(SNMPSecurityModuleError):
+    pass
+
+
+class NoEncryption(SNMPSecurityModuleError):
+    pass
+
+
+class EncryptionError(SNMPSecurityModuleError):
+    pass
+
+
+class DecryptionError(SNMPSecurityModuleError):
+    pass
+
+
+class NoAuthentication(SNMPSecurityModuleError):
+    pass
+
+
+class AuthenticationError(SNMPSecurityModuleError):
+    pass
+
+
+class AuthenticationFailure(SNMPSecurityModuleError):
+    pass
+
+
+class UnsupportedAuthProtocol(SNMPSecurityModuleError):
+    pass
+
+
+class UnsupportedPrivProtocol(SNMPSecurityModuleError):
+    pass
+
+
+class UnknownSecurityName(SNMPSecurityModuleError):
+    pass
+
+
+class UnsupportedSecurityModel(SNMPSecurityModuleError):
+    pass
+
+
+class UnsupportedSecurityLevel(SNMPSecurityModuleError):
+    pass
+
+
+class NotInTimeWindow(SNMPSecurityModuleError):
+    pass
+
+
+class SNMPAccessControlError(SNMPErrorIndication):
+    pass
+
+
+class NoSuchView(SNMPAccessControlError):
+    pass
+
+
+class NoAccessEntry(SNMPAccessControlError):
+    pass
+
+
+class NoGroupName(SNMPAccessControlError):
+    pass
+
+
+class NoSuchContext(SNMPAccessControlError):
+    pass
+
+
+class NotInView(SNMPAccessControlError):
+    pass
+
+
+class AccessAllowed(SNMPAccessControlError):
+    pass
+
+
+class OtherError(SNMPAccessControlError):
+    pass
+
+
+class SNMPApplicationError(SNMPErrorIndication):
+    pass
+
+
+class OidNotIncreasing(SNMPApplicationError):
+    pass

--- a/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
@@ -1,0 +1,34 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import mock
+from virtualpdu.pdu.apc_rackpdu import APCRackPDU
+from virtualpdu.power_states import POWER_OFF
+from virtualpdu.tests import base
+
+
+class TestAPCRackPDU(base.TestCase):
+    def setUp(self):
+        super(TestAPCRackPDU, self).setUp()
+        self.core_mock = mock.Mock()
+        self.pdu = APCRackPDU(name='my_pdu', core=self.core_mock)
+
+    def test_changing_port_state_notifies_core(self):
+        self.pdu.oids[0].value = \
+            self.pdu.get_native_power_state_from_core(POWER_OFF)
+
+        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+            name='my_pdu',
+            outlet_number=1,
+            state=POWER_OFF)

--- a/virtualpdu/tests/unit/pdu/test_base.py
+++ b/virtualpdu/tests/unit/pdu/test_base.py
@@ -1,0 +1,32 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import mock
+from virtualpdu.pdu import PDU
+from virtualpdu.power_states import POWER_OFF
+from virtualpdu.tests import base
+
+
+class TestPDU(base.TestCase):
+    def setUp(self):
+        super(TestPDU, self).setUp()
+        self.core_mock = mock.Mock()
+        self.pdu = PDU(name='my_pdu', core=self.core_mock)
+
+    def test_power_off_notifies_core(self):
+        self.pdu.oids[0].value = 'off'
+        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+            name='my_pdu',
+            outlet_number=1,
+            state=POWER_OFF)

--- a/virtualpdu/tests/unit/test_snmp_client.py
+++ b/virtualpdu/tests/unit/test_snmp_client.py
@@ -1,0 +1,148 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import mock
+from mock import sentinel
+from pysnmp.proto import errind
+from pysnmp.proto.errind import ErrorIndication
+from pysnmp.proto.rfc1905 import NoSuchInstance
+from virtualpdu.tests import base
+from virtualpdu.tests import snmp_client
+from virtualpdu.tests import snmp_error_indications
+
+
+class TestSnmpClient(base.TestCase):
+    def setUp(self):
+        super(TestSnmpClient, self).setUp()
+        self.command_generator_mock = mock.Mock()
+        self.pysnmp_mock = mock.Mock()
+        self.oneliner_cmdgen = mock.Mock()
+
+        self.oneliner_cmdgen.CommandGenerator.return_value = \
+            self.command_generator_mock
+
+        self.oneliner_cmdgen.CommunityData.return_value = \
+            sentinel.community_data
+
+        self.oneliner_cmdgen.UdpTransportTarget.return_value = \
+            sentinel.udp_transport_target
+
+        self.snmp_client = snmp_client.SnmpClient(
+            oneliner_cmdgen=self.oneliner_cmdgen,
+            host=sentinel.hostname,
+            port=sentinel.port,
+            community=sentinel.community,
+            timeout=sentinel.timeout,
+            retries=sentinel.retries,
+        )
+
+        self.all_error_indications = [
+            (errind.__dict__.get(a).__class__.__name__, errind.__dict__.get(a))
+            for a in dir(errind)
+            if isinstance(errind.__dict__.get(a), ErrorIndication)]
+
+    def test_all_error_indications_exist(self):
+        for class_name, error_indication in self.all_error_indications:
+            exception_class = snmp_error_indications.__dict__.get(class_name)
+
+            self.assertIsNotNone(exception_class,
+                                 "Exception class {} was not found in "
+                                 "snmp_client.".format(class_name))
+
+            self.assertIsInstance(exception_class(),
+                                  snmp_error_indications.SNMPErrorIndication,
+                                  class_name)
+
+    def test_get_one(self):
+        oid = (1, 3, 6)
+        self.command_generator_mock.getCmd.return_value = \
+            (None, 0, 0, [(oid, '42 thousands')])
+        value = self.snmp_client.get_one(oid)
+
+        self.assertEqual('42 thousands', value)
+
+        self.oneliner_cmdgen.UdpTransportTarget\
+            .assert_called_with((sentinel.hostname, sentinel.port),
+                                timeout=sentinel.timeout,
+                                retries=sentinel.retries)
+        self.oneliner_cmdgen.CommunityData\
+            .assert_called_with(sentinel.community)
+        self.command_generator_mock.getCmd.assert_called_with(
+            sentinel.community_data,
+            sentinel.udp_transport_target,
+            oid
+        )
+
+    def test_get_with_all_possible_error_indications(self):
+        oid = (1, 3, 6)
+        for class_name, error_indication in self.all_error_indications:
+            self.command_generator_mock.getCmd.return_value = \
+                (error_indication, 0, 0, [])
+
+            exception_class = snmp_error_indications.__dict__.get(class_name)
+
+            self.assertRaises(exception_class,
+                              self.snmp_client.get_one, oid)
+
+    def test_set(self):
+        oid = (1, 3, 6)
+        self.command_generator_mock.setCmd.return_value = \
+            (None, 0, 0, [(oid, '43 thousands')])
+        value = self.snmp_client.set(oid, '43 thousands')
+
+        self.assertEqual('43 thousands', value)
+
+        self.oneliner_cmdgen.UdpTransportTarget\
+            .assert_called_with((sentinel.hostname, sentinel.port),
+                                timeout=sentinel.timeout,
+                                retries=sentinel.retries)
+        self.oneliner_cmdgen.CommunityData\
+            .assert_called_with(sentinel.community)
+        self.command_generator_mock.setCmd.assert_called_with(
+            sentinel.community_data,
+            sentinel.udp_transport_target,
+            (oid, '43 thousands')
+        )
+
+    def test_set_no_such_instance(self):
+        oid = (1, 3, 6)
+        self.command_generator_mock.setCmd.return_value = \
+            (None, 0, 0, [(oid, NoSuchInstance())])
+        value = self.snmp_client.set(oid, '43 thousands')
+
+        self.assertEqual(NoSuchInstance(), value)
+
+        self.oneliner_cmdgen.UdpTransportTarget \
+            .assert_called_with((sentinel.hostname, sentinel.port),
+                                timeout=sentinel.timeout,
+                                retries=sentinel.retries)
+
+        self.oneliner_cmdgen.CommunityData \
+            .assert_called_with(sentinel.community)
+
+        self.command_generator_mock.setCmd.assert_called_with(
+            sentinel.community_data,
+            sentinel.udp_transport_target,
+            (oid, '43 thousands')
+        )
+
+    def test_set_with_all_possible_error_indications(self):
+        oid = (1, 3, 6)
+        for class_name, error_indication in self.all_error_indications:
+            self.command_generator_mock.setCmd.return_value = \
+                (error_indication, 0, 0, [])
+            exception_class = snmp_error_indications.__dict__.get(class_name)
+
+            self.assertRaises(exception_class,
+                              self.snmp_client.set, oid, 'test')


### PR DESCRIPTION
The provided APC RackPDU implementation corresponds to (a subset of) the actual APC RackPDU devices.

Also provided is a PDUTestHarness test class to be able to have an actual PDU listen to SNMP requests. This was done so integration tests can actually run against the test subject in a unitary fashion.

A pysnmp_handler is provided to handle converting an SNMP message to calls on an "OID store". It was mostly sourced from a pysnmp example that is not shipped with the package. Heavily modified for our purposes and code style. This approach was preferred to Twisted-SNMP (and pysnmp-se), because the latter does not support Python 3 and it allows only a single reactor per process. That is incompatible with our integration test approach.

An SNMP client "wrapper" was provided to simplify SNMP requests and to raise exceptions when errors happen, so we can assert them during tests. Ideally, the SNMP wrapper could be extracted into it's own project, but it it deemed small enough to stay here, for now. While looking for alternatives to writing our own wrapper, we found snmpy and nelsnmp. The
former had a limitation around the fact that you were forced to provide an MIB and do lookup by names. It was not possible (short of monkey patching) to strip the name <> OID lookup. On the other hand, nelsnmp worked for direct OID lookups, but did type validation when querying. This prevented duck typing because PDU and PDUOutlets use actual ASN.1 pysnmp objects to avoid any confusion. nelsnmp would check for "int" type and refuse to proceed. An additional mapping table could have been provided, but this was seen as more work. Finally, only generic exceptions were raised, with an error message. This was deemed as a less-than-ideal scenario, especially when trying to assert RequestTimedOut behaviors.
