### PR TITLE
Ensure APCRackPDU instanciation does not update core

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -35,10 +35,11 @@ rPDU_power_mappings = {
 
 
 class APCRackPDUOutlet(PDUOutlet):
+    default_state = rPDU_power_mappings['immediateOn']
+
     def __init__(self, outlet_number, pdu):
         super(APCRackPDUOutlet, self).__init__(outlet_number, pdu)
         self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
-        self.value = rPDU_power_mappings['immediateOn']
 
 
 class APCRackPDU(PDU):

--- a/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
@@ -35,6 +35,8 @@ class TestAPCRackPDU(PDUTestCase):
         self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (7,)))
         self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (8,)))
 
+        self.assertFalse(self.core_mock.pdu_outlet_state_changed.called)
+
     def test_port_state_can_be_changed(self):
         enterprises = (1, 3, 6, 1, 4, 1)
         rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)


### PR DESCRIPTION
Currently, APCRackPDU will notify the core for all of it's port being updated as power state "ON" because of improper usage of the PDU class. In fact, the PDU class provides support for "default" values that bypass the callback.

This commit uses the right field and adds a unit test to cover that case.
