### PR TITLE
Fixing intermittent unit test failures

### DIFF
--- a/virtualpdu/tests/unit/drivers/test_libvirt_driver.py
+++ b/virtualpdu/tests/unit/drivers/test_libvirt_driver.py
@@ -128,8 +128,8 @@ class TestLibvirtDriver(base.TestCase):
         connection_mock.lookupByName.return_value = domain_mock
 
         domain_mock.create.side_effect = \
-            libvirt.libvirtError(DOMAIN_ALREADY_RUNNING.format(domain_name),
-                                 conn=connection_mock)
+            DumbLibvirtError(DOMAIN_ALREADY_RUNNING.format(domain_name),
+                             conn=connection_mock)
         mock_open.return_value = connection_mock
 
         self.driver.power_on(domain_name)
@@ -171,3 +171,14 @@ class TestKeepaliveLibvirtDriver(base.TestCase):
 
 class SpecificException(Exception):
     pass
+
+
+class DumbLibvirtError(libvirt.libvirtError):
+    def __init__(self, defmsg, conn=None, dom=None, net=None,
+                 pool=None, vol=None):
+        # NOTE(walhawari): Libvirt fetches "last error" and if that
+        #                  returns anything, defmsg is simply ignored.
+        #                  Work around this design limitation by creating an
+        #                  exception that derives from libvirtError but doesn't
+        #                  have this behavior.
+        Exception.__init__(self, defmsg)


### PR DESCRIPTION
It was discovered that libvirt checks the last error that was raised, so
the validation of current exceptions was not being caught properly since
the last error was always grabbed. Creating a 'dummy' Error class that
bypasses the forcing of grabbing the last error solves this
