### PR TITLE
Handle SIGINT correctly on Python 2.7

### DIFF
--- a/virtualpdu/core.py
+++ b/virtualpdu/core.py
@@ -27,11 +27,13 @@ class Core(object):
     def pdu_outlet_state_changed(self, name, outlet_number, state):
         self.logger.info(
             "PDU '{name}', outlet '{outlet_number}' has new state: '{state}'".
-            format(name=name, outlet_number=outlet_number, state=state))
+                format(name=name, outlet_number=outlet_number, state=state))
         try:
             server_name = self._get_server_name(name, outlet_number)
 
-            self.logger.info("Found server '{0}'".format(server_name))
+            self.logger.debug("Found server '{0}' on PDU '{1}', "
+                              "outlet '{2}'".format(server_name, name,
+                                                  outlet_number))
         except KeyError:
             return
 

--- a/virtualpdu/pdu/pysnmp_handler.py
+++ b/virtualpdu/pdu/pysnmp_handler.py
@@ -102,6 +102,8 @@ class SNMPPDUHandler(object):
 class SNMPPDUHarness(threading.Thread):
     def __init__(self, pdu, listen_address, listen_port, community="public"):
         super(SNMPPDUHarness, self).__init__()
+        self.logger = logging.getLogger(__name__)
+
         self.pdu = pdu
 
         self.snmp_handler = SNMPPDUHandler(self.pdu, community=community)
@@ -111,6 +113,10 @@ class SNMPPDUHarness(threading.Thread):
         self.transportDispatcher = AsyncoreDispatcher()
 
     def run(self):
+        self.logger.info("Starting PDU '{name}' on {host}:{port}".
+              format(name=self.pdu.name,
+                     host=self.listen_address,
+                     port=self.listen_port))
         self.transportDispatcher.registerRecvCbFun(
             self.snmp_handler.message_handler)
 


### PR DESCRIPTION
Currently, VirtualPDU is unstoppable on Python 2.7. Correct this by handling KeyboardInterrupt events in the main thread.

Closes issues #14 and #16
