### PR TITLE
Support listen_address in config instead of listen_host

### DIFF
--- a/virtualpdu/main.py
+++ b/virtualpdu/main.py
@@ -43,7 +43,7 @@ def main():
 
             apc_pdu = apc_rackpdu.APCRackPDU(pdu, core)
 
-            listen_address = config.get(pdu, 'listen_host')
+            listen_address = config.get(pdu, 'listen_address')
             port = int(config.get(pdu, 'listen_port'))
             community = config.get(pdu, 'community')
 

--- a/virtualpdu/tests/integration/test_entrypoint.py
+++ b/virtualpdu/tests/integration/test_entrypoint.py
@@ -27,13 +27,13 @@ TEST_CONFIG = """[global]
 libvirt_uri=test:///default
 
 [my_pdu]
-listen_host=127.0.0.1
+listen_address=127.0.0.1
 listen_port=9998
 community=public
 ports=5:test
 
 [my_second_pdu]
-listen_host=127.0.0.1
+listen_address=127.0.0.1
 listen_port=9997
 community=public
 ports=2:test


### PR DESCRIPTION
listen_address was the intended name but listen_host was written in the
tests, which led to us read from listen_host, but use listen_address
throughout the code.

Solve this by reading listen_address only. Backwards compatibility is
not a concern as this is pre-release software, and there are no official
uses of it yet.

Closes #19
