### PR TITLE
Outlet's default power state is now configurable

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -14,31 +14,37 @@
 
 from pyasn1.type import univ
 
-from virtualpdu.core import POWER_OFF
-from virtualpdu.core import POWER_ON
-from virtualpdu.core import REBOOT
+from virtualpdu import core
+from virtualpdu.pdu import BasePDUOutletStates
 from virtualpdu.pdu import PDU
 from virtualpdu.pdu import PDUOutlet
 
 rPDU_outlet_control_outlet_command = \
     (1, 3, 6, 1, 4, 1, 318, 1, 1, 12, 3, 3, 1, 1, 4)
 
-rPDU_power_mappings = {
-    'immediateOn': univ.Integer(1),
-    'immediateOff': univ.Integer(2),
-    'immediateReboot': univ.Integer(3),
-    'delayedOn': univ.Integer(4),
-    'delayedOff': univ.Integer(5),
-    'delayedReboot': univ.Integer(6),
-    'cancelPendingCommand': univ.Integer(7),
-}
+
+class APCRackPDUOutletStates(BasePDUOutletStates):
+    IMMEDIATE_ON = univ.Integer(1)
+    IMMEDIATE_OFF = univ.Integer(2)
+    IMMEDIATE_REBOOT = univ.Integer(3)
+    DELAYED_ON = univ.Integer(4)
+    DELAYED_OFF = univ.Integer(5)
+    DELAYED_REBOOT = univ.Integer(6)
+    CANCEL_PENDING_COMMAND = univ.Integer(7)
+
+    to_core_mapping = {
+        IMMEDIATE_ON: core.POWER_ON,
+        IMMEDIATE_OFF: core.POWER_OFF,
+        IMMEDIATE_REBOOT: core.REBOOT
+    }
 
 
 class APCRackPDUOutlet(PDUOutlet):
-    default_state = rPDU_power_mappings['immediateOn']
+    states = APCRackPDUOutletStates()
 
-    def __init__(self, outlet_number, pdu):
-        super(APCRackPDUOutlet, self).__init__(outlet_number, pdu)
+    def __init__(self, outlet_number, pdu, default_state):
+        super(APCRackPDUOutlet, self).__init__(
+            outlet_number, pdu, default_state)
         self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
 
 
@@ -46,14 +52,3 @@ class APCRackPDU(PDU):
     outlet_count = 8
     outlet_index_start = 1
     outlet_class = APCRackPDUOutlet
-    power_states = {
-        rPDU_power_mappings['immediateOn']: POWER_ON,
-        rPDU_power_mappings['immediateOff']: POWER_OFF,
-        rPDU_power_mappings['immediateReboot']: REBOOT,
-    }
-
-    core_to_native_power_states = {
-        POWER_ON: rPDU_power_mappings['immediateOn'],
-        POWER_OFF: rPDU_power_mappings['immediateOff'],
-        REBOOT: rPDU_power_mappings['immediateReboot']
-    }

--- a/virtualpdu/pdu/pysnmp_handler.py
+++ b/virtualpdu/pdu/pysnmp_handler.py
@@ -65,14 +65,14 @@ class SNMPPDUHandler(object):
                 for oid, val in protocol.apiPDU.getVarBinds(request_pdus):
                     if oid in self.pdu.oid_mapping:
                         var_binds.append(
-                            (oid, self.pdu.oid_mapping[oid].value))
+                            (oid, self.pdu.oid_mapping[oid].state))
                     else:
                         return
             elif request_pdus.isSameTypeWith(protocol.SetRequestPDU()):
                 for oid, val in protocol.apiPDU.getVarBinds(request_pdus):
                     error_index += 1
                     if oid in self.pdu.oid_mapping:
-                        self.pdu.oid_mapping[oid].value = val
+                        self.pdu.oid_mapping[oid].state = val
                         var_binds.append((oid, val))
                     else:
                         var_binds.append((oid, val))

--- a/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from virtualpdu.core import POWER_OFF
-from virtualpdu.core import POWER_ON
 from virtualpdu.pdu.apc_rackpdu import APCRackPDU
 
 from virtualpdu.tests.integration.pdu import PDUTestCase
@@ -42,13 +40,10 @@ class TestAPCRackPDU(PDUTestCase):
         rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)
         outlet_1 = enterprises + rPDUControl + (1,)
 
-        native_power_on = self.pdu.get_native_power_state_from_core(POWER_ON)
-        native_power_off = self.pdu.get_native_power_state_from_core(POWER_OFF)
-
-        self.assertEqual(native_power_on,
+        self.assertEqual(self.pdu.outlet_class.states.IMMEDIATE_ON,
                          self.snmp_get(outlet_1))
 
-        self.snmp_set(outlet_1, native_power_off)
+        self.snmp_set(outlet_1, self.pdu.outlet_class.states.IMMEDIATE_OFF)
 
-        self.assertEqual(native_power_off,
+        self.assertEqual(self.pdu.outlet_class.states.IMMEDIATE_OFF,
                          self.snmp_get(outlet_1))

--- a/virtualpdu/tests/integration/pdu/test_pdu.py
+++ b/virtualpdu/tests/integration/pdu/test_pdu.py
@@ -34,10 +34,14 @@ class TestPDU(PDUTestCase):
                          self.snmp_set(enterprises + (42,), univ.Integer(7)))
 
     def test_get_valid_oid_wrong_community(self):
+        default_state = self.pdu.outlet_class.states.ON
         self.pdu.oid_mapping[enterprises + (88, 1)] = \
-            pdu.PDUOutlet(outlet_number=1, pdu=self.pdu)
+            pdu.PDUOutlet(outlet_number=1,
+                          pdu=self.pdu,
+                          default_state=default_state)
 
-        self.assertEqual(1, self.snmp_get(enterprises + (88, 1)))
+        self.assertEqual(self.pdu.outlet_class.states.ON,
+                         self.snmp_get(enterprises + (88, 1)))
 
         self.assertRaises(RequestTimedOut,
                           self.snmp_get, enterprises + (88, 1),
@@ -45,5 +49,6 @@ class TestPDU(PDUTestCase):
 
     def test_set_wrong_community(self):
         self.assertRaises(RequestTimedOut,
-                          self.snmp_set, enterprises + (42,), univ.Integer(1),
+                          self.snmp_set, enterprises + (42,),
+                          self.pdu.outlet_class.states.ON,
                           community='wrong')

--- a/virtualpdu/tests/integration/pdu/test_pysnmp_handler.py
+++ b/virtualpdu/tests/integration/pdu/test_pysnmp_handler.py
@@ -44,7 +44,7 @@ class TestSNMPPDUHarness(base.TestCase):
 
         mock_pdu.oid_mapping = dict()
         mock_pdu.oid_mapping[(1, 3, 6, 99)] = mock.Mock()
-        mock_pdu.oid_mapping[(1, 3, 6, 99)].value = univ.Integer(42)
+        mock_pdu.oid_mapping[(1, 3, 6, 99)].state = univ.Integer(42)
 
         self.assertEqual(42, client.get_one((1, 3, 6, 99)))
 
@@ -74,6 +74,6 @@ class TestSNMPPDUHarness(base.TestCase):
         client.set((1, 3, 6, 98), univ.Integer(99))
 
         self.assertEqual(univ.Integer(99),
-                         mock_pdu.oid_mapping[(1, 3, 6, 98)].value)
+                         mock_pdu.oid_mapping[(1, 3, 6, 98)].state)
 
         harness.stop()

--- a/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
+++ b/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
@@ -17,8 +17,8 @@ from virtualpdu import core
 
 class BasePDUTests(object):
     def test_power_on_notifies_core(self):
-        self.pdu.oids[0].value = \
-            self.pdu.get_native_power_state_from_core(core.POWER_ON)
+        self.pdu.oids[0].state = \
+            self.pdu.outlet_class.states.from_core(core.POWER_ON)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
             name='my_pdu',
@@ -26,8 +26,8 @@ class BasePDUTests(object):
             state=core.POWER_ON)
 
     def test_reboot_notifies_core(self):
-        self.pdu.oids[0].value = \
-            self.pdu.get_native_power_state_from_core(core.REBOOT)
+        self.pdu.oids[0].state = \
+            self.pdu.outlet_class.states.from_core(core.REBOOT)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
             name='my_pdu',
@@ -35,8 +35,8 @@ class BasePDUTests(object):
             state=core.REBOOT)
 
     def test_power_off_notifies_core(self):
-        self.pdu.oids[0].value = \
-            self.pdu.get_native_power_state_from_core(core.POWER_OFF)
+        self.pdu.oids[0].state = \
+            self.pdu.outlet_class.states.from_core(core.POWER_OFF)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
             name='my_pdu',


### PR DESCRIPTION
Enables to specify "OFF" or "ON" in the configuration to change the
default behavior of the outlets.With devstack, libvirt starts with
power_state to OFF, this clash with the current behavior of the APC
for having power_states enabled by default.

A PDU can now represent his state with an internal object instead
of a snmp_value. The 'value' field of PDU was ambiguous. It was destined
to be a native_value but was used as a snmp_value in the APC PDU. There
was a translation missing between native_value and snmp_value, so now a
PDU can have his internal object as a state and do the translation on
demand to a snmp_value.
