### PR TITLE
Add Baytech MRP27 support

### DIFF
--- a/virtualpdu/pdu/baytech_mrp27.py
+++ b/virtualpdu/pdu/baytech_mrp27.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyasn1.type import univ
+
+from virtualpdu import core
+from virtualpdu.pdu import BasePDUOutletStates
+from virtualpdu.pdu import PDU
+from virtualpdu.pdu import PDUOutlet
+
+sBTA_modules_RPC_outlet_state = (1, 3, 6, 1, 4, 1, 4779, 1, 3, 5, 3, 1, 3)
+
+
+class BaytechMRP27PDUOutletStates(BasePDUOutletStates):
+    OFF = univ.Integer(0)
+    ON = univ.Integer(1)
+    REBOOT = univ.Integer(2)
+    LOCKON = univ.Integer(3)
+    LOCKOFF = univ.Integer(4)
+    UNLOCK = univ.Integer(5)
+
+    to_core_mapping = {
+        ON: core.POWER_ON,
+        OFF: core.POWER_OFF,
+        REBOOT: core.REBOOT
+    }
+
+
+class BaytechMRP27PDUOutlet(PDUOutlet):
+    states = BaytechMRP27PDUOutletStates()
+
+    def __init__(self, outlet_number, pdu, default_state):
+        super(BaytechMRP27PDUOutlet, self).__init__(
+            outlet_number, pdu, default_state)
+        self.oid = sBTA_modules_RPC_outlet_state + (1, self.outlet_number)
+
+
+class BaytechMRP27PDU(PDU):
+    outlet_count = 24
+    outlet_index_start = 1
+    outlet_class = BaytechMRP27PDUOutlet

--- a/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
+++ b/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from virtualpdu.pdu.baytech_mrp27 import BaytechMRP27PDU
+
+from virtualpdu.tests.integration.pdu import PDUTestCase
+
+
+class TestBaytechMRP27PDU(PDUTestCase):
+    pdu_class = BaytechMRP27PDU
+
+    def test_all_ports_are_on_by_default(self):
+        outlet_state_oid = (1, 3, 6, 1, 4, 1) + (4779, 1, 3, 5, 3, 1, 3)
+
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 1)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 2)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 3)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 4)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 5)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 6)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 7)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 8)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 9)))
+        self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 10)))
+
+        self.assertFalse(self.core_mock.pdu_outlet_state_changed.called)
+
+    def test_port_state_can_be_changed(self):
+        outlet_state_oid = (1, 3, 6, 1, 4, 1) + (4779, 1, 3, 5, 3, 1, 3)
+        outlet_1 = outlet_state_oid + (1, 1)
+
+        self.assertEqual(self.pdu.outlet_class.states.ON,
+                         self.snmp_get(outlet_1))
+
+        self.snmp_set(outlet_1, self.pdu.outlet_class.states.OFF)
+
+        self.assertEqual(self.pdu.outlet_class.states.OFF,
+                         self.snmp_get(outlet_1))

--- a/virtualpdu/tests/unit/pdu/test_baytech_mrp27.py
+++ b/virtualpdu/tests/unit/pdu/test_baytech_mrp27.py
@@ -1,0 +1,26 @@
+# Copyright 2016 Internap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import mock
+
+from virtualpdu.pdu.baytech_mrp27 import BaytechMRP27PDU
+from virtualpdu.tests import base
+from virtualpdu.tests.unit.pdu.base_pdu_test_cases import BasePDUTests
+
+
+class TestBaytechMRP27PDU(base.TestCase, BasePDUTests):
+    def setUp(self):
+        super(TestBaytechMRP27PDU, self).setUp()
+        self.core_mock = mock.Mock()
+        self.pdu = BaytechMRP27PDU(name='my_pdu', core=self.core_mock)


### PR DESCRIPTION
Allows to change the outlet state (ON/OFF/REBOOT) with the right OID
(sBTAModulesRPCOutletState) on Baytech MRP27 pdu.
