### PR TITLE
Move the outlet state responsibility to the core

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -42,9 +42,9 @@ class APCRackPDUOutletStates(BasePDUOutletStates):
 class APCRackPDUOutlet(PDUOutlet):
     states = APCRackPDUOutletStates()
 
-    def __init__(self, outlet_number, pdu, default_state):
+    def __init__(self, outlet_number, pdu):
         super(APCRackPDUOutlet, self).__init__(
-            outlet_number, pdu, default_state)
+            outlet_number, pdu)
         self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
 
 

--- a/virtualpdu/pdu/baytech_mrp27.py
+++ b/virtualpdu/pdu/baytech_mrp27.py
@@ -40,9 +40,9 @@ class BaytechMRP27PDUOutletStates(BasePDUOutletStates):
 class BaytechMRP27PDUOutlet(PDUOutlet):
     states = BaytechMRP27PDUOutletStates()
 
-    def __init__(self, outlet_number, pdu, default_state):
+    def __init__(self, outlet_number, pdu):
         super(BaytechMRP27PDUOutlet, self).__init__(
-            outlet_number, pdu, default_state)
+            outlet_number, pdu)
         self.oid = sBTA_modules_RPC_outlet_state + (1, self.outlet_number)
 
 

--- a/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from virtualpdu import core
 from virtualpdu.pdu.apc_rackpdu import APCRackPDU
 
 from virtualpdu.tests.integration.pdu import PDUTestCase
@@ -21,6 +21,8 @@ class TestAPCRackPDU(PDUTestCase):
     pdu_class = APCRackPDU
 
     def test_all_ports_are_on_by_default(self):
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
+
         enterprises = (1, 3, 6, 1, 4, 1)
         rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)
 
@@ -40,10 +42,14 @@ class TestAPCRackPDU(PDUTestCase):
         rPDUControl = (318, 1, 1, 12, 3, 3, 1, 1, 4)
         outlet_1 = enterprises + rPDUControl + (1,)
 
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
         self.assertEqual(self.pdu.outlet_class.states.IMMEDIATE_ON,
                          self.snmp_get(outlet_1))
 
         self.snmp_set(outlet_1, self.pdu.outlet_class.states.IMMEDIATE_OFF)
+        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+            pdu=self.pdu.name, outlet=1, state=core.POWER_OFF)
 
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_OFF
         self.assertEqual(self.pdu.outlet_class.states.IMMEDIATE_OFF,
                          self.snmp_get(outlet_1))

--- a/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
+++ b/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from virtualpdu import core
 from virtualpdu.pdu.baytech_mrp27 import BaytechMRP27PDU
 
 from virtualpdu.tests.integration.pdu import PDUTestCase
@@ -21,6 +21,8 @@ class TestBaytechMRP27PDU(PDUTestCase):
     pdu_class = BaytechMRP27PDU
 
     def test_all_ports_are_on_by_default(self):
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
+
         outlet_state_oid = (1, 3, 6, 1, 4, 1) + (4779, 1, 3, 5, 3, 1, 3)
 
         self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 1)))
@@ -40,10 +42,14 @@ class TestBaytechMRP27PDU(PDUTestCase):
         outlet_state_oid = (1, 3, 6, 1, 4, 1) + (4779, 1, 3, 5, 3, 1, 3)
         outlet_1 = outlet_state_oid + (1, 1)
 
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
         self.assertEqual(self.pdu.outlet_class.states.ON,
                          self.snmp_get(outlet_1))
 
         self.snmp_set(outlet_1, self.pdu.outlet_class.states.OFF)
+        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+            pdu=self.pdu.name, outlet=1, state=core.POWER_OFF)
 
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_OFF
         self.assertEqual(self.pdu.outlet_class.states.OFF,
                          self.snmp_get(outlet_1))

--- a/virtualpdu/tests/integration/pdu/test_pdu.py
+++ b/virtualpdu/tests/integration/pdu/test_pdu.py
@@ -15,6 +15,7 @@
 from pyasn1.type import univ
 from pysnmp.proto.rfc1905 import NoSuchInstance
 
+from virtualpdu import core
 from virtualpdu import pdu
 from virtualpdu.tests.integration.pdu import PDUTestCase
 from virtualpdu.tests.snmp_error_indications import RequestTimedOut
@@ -34,11 +35,10 @@ class TestPDU(PDUTestCase):
                          self.snmp_set(enterprises + (42,), univ.Integer(7)))
 
     def test_get_valid_oid_wrong_community(self):
-        default_state = self.pdu.outlet_class.states.ON
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
         self.pdu.oid_mapping[enterprises + (88, 1)] = \
             pdu.PDUOutlet(outlet_number=1,
-                          pdu=self.pdu,
-                          default_state=default_state)
+                          pdu=self.pdu)
 
         self.assertEqual(self.pdu.outlet_class.states.ON,
                          self.snmp_get(enterprises + (88, 1)))

--- a/virtualpdu/tests/integration/test_core_integration.py
+++ b/virtualpdu/tests/integration/test_core_integration.py
@@ -32,7 +32,9 @@ class TestCoreIntegration(base.TestCase):
         self.core = core.Core(driver=self.driver,
                               mapping={
                                   ('my_pdu', 5): 'test'
-                              })
+                              },
+                              store={},
+                              default_state=core.POWER_OFF)
 
         self.outlet_oid = apc_rackpdu.rPDU_outlet_control_outlet_command + (5,)
 
@@ -73,14 +75,22 @@ class TestCoreIntegration(base.TestCase):
                          self.driver.get_power_state('test'))
 
     def test_initial_outlet_power_state_on(self):
-        pdu = apc_rackpdu.APCRackPDU('my_pdu', self.core, core.POWER_ON)
+        my_core = core.Core(driver=self.driver,
+                            mapping={},
+                            store={},
+                            default_state=core.POWER_ON)
+        pdu = apc_rackpdu.APCRackPDU('my_pdu', my_core)
         snmp_client_ = self.get_harness_client(pdu)
 
         self.assertEqual(pdu.outlet_class.states.IMMEDIATE_ON,
                          snmp_client_.get_one(self.outlet_oid))
 
     def test_initial_outlet_power_state_off(self):
-        pdu = apc_rackpdu.APCRackPDU('my_pdu', self.core, core.POWER_OFF)
+        my_core = core.Core(driver=self.driver,
+                            mapping={},
+                            store={},
+                            default_state=core.POWER_OFF)
+        pdu = apc_rackpdu.APCRackPDU('my_pdu', my_core)
         snmp_client_ = self.get_harness_client(pdu)
 
         self.assertEqual(pdu.outlet_class.states.IMMEDIATE_OFF,

--- a/virtualpdu/tests/integration/test_entrypoint.py
+++ b/virtualpdu/tests/integration/test_entrypoint.py
@@ -128,8 +128,10 @@ class TestEntryPointIntegration(base.TestCase):
 
     def test_entrypoint_raise_on_invalid_mode(self):
         with tempfile.NamedTemporaryFile() as f:
-            test_config2 = TEST_CONFIG + """outlet_default_state = invalid_mode
-                    """
+            test_config2 = """[global]
+libvirt_uri=test:///default
+outlet_default_state = invalid_mode
+"""
             f.write(bytearray(test_config2, encoding='utf-8'))
             f.flush()
             try:

--- a/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
+++ b/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
@@ -21,8 +21,8 @@ class BasePDUTests(object):
             self.pdu.outlet_class.states.from_core(core.POWER_ON)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
-            name='my_pdu',
-            outlet_number=1,
+            pdu='my_pdu',
+            outlet=1,
             state=core.POWER_ON)
 
     def test_reboot_notifies_core(self):
@@ -30,8 +30,8 @@ class BasePDUTests(object):
             self.pdu.outlet_class.states.from_core(core.REBOOT)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
-            name='my_pdu',
-            outlet_number=1,
+            pdu='my_pdu',
+            outlet=1,
             state=core.REBOOT)
 
     def test_power_off_notifies_core(self):
@@ -39,6 +39,30 @@ class BasePDUTests(object):
             self.pdu.outlet_class.states.from_core(core.POWER_OFF)
 
         self.core_mock.pdu_outlet_state_changed.assert_called_with(
-            name='my_pdu',
-            outlet_number=1,
+            pdu='my_pdu',
+            outlet=1,
             state=core.POWER_OFF)
+
+    def test_read_power_on(self):
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
+
+        self.assertEqual(
+            self.pdu.outlet_class.states.from_core(core.POWER_ON),
+            self.pdu.oids[0].state
+        )
+
+        self.core_mock.get_pdu_outlet_state.assert_called_with(
+            pdu='my_pdu',
+            outlet=1)
+
+    def test_read_power_off(self):
+        self.core_mock.get_pdu_outlet_state.return_value = core.POWER_OFF
+
+        self.assertEqual(
+            self.pdu.outlet_class.states.from_core(core.POWER_OFF),
+            self.pdu.oids[0].state
+        )
+
+        self.core_mock.get_pdu_outlet_state.assert_called_with(
+            pdu='my_pdu',
+            outlet=1)


### PR DESCRIPTION
Now, the core stores the outlet state and the SNMP PDU adapter only
notifies and consult the core about the state of an outlet.  In the
case where the outlet has never been set, the driver is queried to get
the outlet state.  In the event that there is no device (libvirt
domain) associated to an outlet, the default outlet state from the
configuration will be returned.

Also, the outlet default state is now in the "global" section of the
configuration as there is no outlet defalut state per PDU anymore.

```
[global]
outlet_default_state = ON
```
