### PR TITLE
Let PDU outlets notify the core directly

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -42,9 +42,9 @@ class APCRackPDUOutletStates(BasePDUOutletStates):
 class APCRackPDUOutlet(PDUOutlet):
     states = APCRackPDUOutletStates()
 
-    def __init__(self, outlet_number, pdu):
+    def __init__(self, pdu_name, outlet_number, core):
         super(APCRackPDUOutlet, self).__init__(
-            outlet_number, pdu)
+            pdu_name, outlet_number, core)
         self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
 
 

--- a/virtualpdu/pdu/baytech_mrp27.py
+++ b/virtualpdu/pdu/baytech_mrp27.py
@@ -40,9 +40,9 @@ class BaytechMRP27PDUOutletStates(BasePDUOutletStates):
 class BaytechMRP27PDUOutlet(PDUOutlet):
     states = BaytechMRP27PDUOutletStates()
 
-    def __init__(self, outlet_number, pdu):
+    def __init__(self, pdu_name, outlet_number, core):
         super(BaytechMRP27PDUOutlet, self).__init__(
-            outlet_number, pdu)
+            pdu_name, outlet_number, core)
         self.oid = sBTA_modules_RPC_outlet_state + (1, self.outlet_number)
 
 

--- a/virtualpdu/tests/integration/pdu/test_pdu.py
+++ b/virtualpdu/tests/integration/pdu/test_pdu.py
@@ -37,8 +37,9 @@ class TestPDU(PDUTestCase):
     def test_get_valid_oid_wrong_community(self):
         self.core_mock.get_pdu_outlet_state.return_value = core.POWER_ON
         self.pdu.oid_mapping[enterprises + (88, 1)] = \
-            pdu.PDUOutlet(outlet_number=1,
-                          pdu=self.pdu)
+            pdu.PDUOutlet(pdu_name=self.pdu.name,
+                          outlet_number=1,
+                          core=self.core_mock)
 
         self.assertEqual(self.pdu.outlet_class.states.ON,
                          self.snmp_get(enterprises + (88, 1)))


### PR DESCRIPTION
In order to remove the mutual dependency of the PDU and the PDUOutlet
class, the PDUOutlet class will be responsible to talk to the core and
make the appropriate data transformations.

This will allow the PDU class to, eventually, manage more OID registers
associated to the outlet than simply its state.
