### PR TITLE
Provide sys description and sys OID

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -18,13 +18,16 @@ from virtualpdu import core
 from virtualpdu.pdu import BasePDUOutletStates
 from virtualpdu.pdu import PDU
 from virtualpdu.pdu import PDUOutletControl
-from virtualpdu.pdu import PDUOutletRegister
+from virtualpdu.pdu import PDUOutletFeature
+from virtualpdu.pdu import static_info
+from virtualpdu.pdu import sysDescr
+from virtualpdu.pdu import sysObjectID
 
-rPDU_outlet_control_outlet_command = \
-    (1, 3, 6, 1, 4, 1, 318, 1, 1, 12, 3, 3, 1, 1, 4)
 
-rPDU_outlet_config_outlet_name = \
-    (1, 3, 6, 1, 4, 1, 318, 1, 1, 12, 3, 4, 1, 1, 2)
+rPDU = (1, 3, 6, 1, 4, 1, 318, 1, 1, 12)
+rPDU_outlet_control_outlet_command = rPDU + (3, 3, 1, 1, 4)
+rPDU_outlet_config_index = rPDU + (3, 4, 1, 1, 1)
+rPDU_outlet_config_outlet_name = rPDU + (3, 4, 1, 1, 2)
 
 
 class APCRackPDUOutletStates(BasePDUOutletStates):
@@ -52,7 +55,7 @@ class APCRackPDUOutletControl(PDUOutletControl):
         self.oid = rPDU_outlet_control_outlet_command + (self.outlet_number, )
 
 
-class APCRackPDUOutletName(PDUOutletRegister):
+class APCRackPDUOutletName(PDUOutletFeature):
     states = APCRackPDUOutletStates()
 
     def __init__(self, pdu_name, outlet_number, core):
@@ -68,4 +71,8 @@ class APCRackPDUOutletName(PDUOutletRegister):
 class APCRackPDU(PDU):
     outlet_count = 8
     outlet_index_start = 1
-    outlet_classes = [APCRackPDUOutletControl, APCRackPDUOutletName]
+    outlet_features = [APCRackPDUOutletControl, APCRackPDUOutletName]
+    general_features = [
+        static_info(sysDescr, univ.OctetString("APC Rack PDU (virtualpdu)")),
+        static_info(sysObjectID, univ.ObjectIdentifier(rPDU)),
+    ]

--- a/virtualpdu/pdu/baytech_mrp27.py
+++ b/virtualpdu/pdu/baytech_mrp27.py
@@ -18,8 +18,12 @@ from virtualpdu import core
 from virtualpdu.pdu import BasePDUOutletStates
 from virtualpdu.pdu import PDU
 from virtualpdu.pdu import PDUOutletControl
+from virtualpdu.pdu import sysDescr
+from virtualpdu.pdu import sysObjectID
+from virtualpdu.pdu import static_info
 
-sBTA_modules_RPC_outlet_state = (1, 3, 6, 1, 4, 1, 4779, 1, 3, 5, 3, 1, 3)
+sBTA = (1, 3, 6, 1, 4, 1, 4779)
+sBTA_modules_RPC_outlet_state = sBTA + (1, 3, 5, 3, 1, 3)
 
 
 class BaytechMRP27PDUOutletStates(BasePDUOutletStates):
@@ -49,4 +53,9 @@ class BaytechMRP27PDUOutletControl(PDUOutletControl):
 class BaytechMRP27PDU(PDU):
     outlet_count = 24
     outlet_index_start = 1
-    outlet_classes = [BaytechMRP27PDUOutletControl]
+    outlet_features = [BaytechMRP27PDUOutletControl]
+    general_features = [
+        static_info(sysDescr, univ.OctetString(
+            "Universal RPC Host Module (virtualpdu)")),
+        static_info(sysObjectID, univ.ObjectIdentifier(sBTA)),
+    ]

--- a/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from pyasn1.type import univ
 from virtualpdu.pdu import apc_rackpdu
+from virtualpdu.pdu import sysDescr
+from virtualpdu.pdu import sysObjectID
 from virtualpdu.tests import base
 from virtualpdu.tests.unit.pdu.base_pdu_test_cases import BasePDUTests
 
@@ -32,4 +34,16 @@ class TestAPCRackPDU(base.TestCase, BasePDUTests):
         self.assertEqual(
             univ.OctetString('Outlet #1'),
             outlet_name.value
+        )
+
+    def test_read_system_description(self):
+        self.assertEqual(
+            univ.OctetString("APC Rack PDU (virtualpdu)"),
+            self.pdu.oid_mapping[sysDescr].value
+        )
+
+    def test_read_system_oid(self):
+        self.assertEqual(
+            univ.ObjectIdentifier(apc_rackpdu.rPDU),
+            self.pdu.oid_mapping[sysObjectID].value
         )

--- a/virtualpdu/tests/unit/pdu/test_baytech_mrp27.py
+++ b/virtualpdu/tests/unit/pdu/test_baytech_mrp27.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pyasn1.type import univ
 
 from virtualpdu.pdu import baytech_mrp27
+from virtualpdu.pdu import sysObjectID
+from virtualpdu.pdu import sysDescr
 from virtualpdu.tests import base
 from virtualpdu.tests.unit.pdu.base_pdu_test_cases import BasePDUTests
 
@@ -22,3 +25,15 @@ class TestBaytechMRP27PDU(base.TestCase, BasePDUTests):
     outlet_control_oid = \
         baytech_mrp27.sBTA_modules_RPC_outlet_state \
         + (1, baytech_mrp27.BaytechMRP27PDU.outlet_index_start,)
+
+    def test_read_system_description(self):
+        self.assertEqual(
+            univ.OctetString("Universal RPC Host Module (virtualpdu)"),
+            self.pdu.oid_mapping[sysDescr].value
+        )
+
+    def test_read_system_oid(self):
+        self.assertEqual(
+            univ.ObjectIdentifier(baytech_mrp27.sBTA),
+            self.pdu.oid_mapping[sysObjectID].value
+        )


### PR DESCRIPTION
This commit introduce the possibility to define read only PDU properties as
sysDesc or sysObjectID.

Reference: http://www.oid-info.com/get/1.3.6.1.2.1.1
