### PR TITLE
Fixes internap/virtualpdu#30

### DIFF
--- a/virtualpdu/drivers/libvirt_driver.py
+++ b/virtualpdu/drivers/libvirt_driver.py
@@ -43,7 +43,11 @@ class LibvirtDriver(drivers.Driver):
     def power_off(self, name):
         with self._connect() as connection:
             domain = safe_lookup_by_name(connection, name)
-            domain.destroy()
+            try:
+                domain.destroy()
+            except libvirt.libvirtError as e:
+                if 'is not running' not in str(e):
+                    raise
 
     def get_power_state(self, name):
         with self._connect() as connection:


### PR DESCRIPTION
Exception handling has been added to the libvirt driver's power_off feature.
This fixes the issue where an uncaught exception would raise when a power_off
command would be issued when the PDU is already off.