### PR TITLE
Provide accurate APC rPDU sys OID

### DIFF
--- a/virtualpdu/pdu/apc_rackpdu.py
+++ b/virtualpdu/pdu/apc_rackpdu.py
@@ -24,6 +24,8 @@ from virtualpdu.pdu import sysDescr
 from virtualpdu.pdu import sysObjectID
 
 
+rPDU_sysObjectID = (1, 3, 6, 1, 4, 1, 318, 1, 3, 4, 6)
+
 rPDU = (1, 3, 6, 1, 4, 1, 318, 1, 1, 12)
 rPDU_outlet_control_outlet_command = rPDU + (3, 3, 1, 1, 4)
 rPDU_outlet_config_index = rPDU + (3, 4, 1, 1, 1)
@@ -74,5 +76,5 @@ class APCRackPDU(PDU):
     outlet_features = [APCRackPDUOutletControl, APCRackPDUOutletName]
     general_features = [
         static_info(sysDescr, univ.OctetString("APC Rack PDU (virtualpdu)")),
-        static_info(sysObjectID, univ.ObjectIdentifier(rPDU)),
+        static_info(sysObjectID, univ.ObjectIdentifier(rPDU_sysObjectID)),
     ]

--- a/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/unit/pdu/test_apc_rackpdu.py
@@ -44,6 +44,6 @@ class TestAPCRackPDU(base.TestCase, BasePDUTests):
 
     def test_read_system_oid(self):
         self.assertEqual(
-            univ.ObjectIdentifier(apc_rackpdu.rPDU),
+            univ.ObjectIdentifier(apc_rackpdu.rPDU_sysObjectID),
             self.pdu.oid_mapping[sysObjectID].value
         )


### PR DESCRIPTION
The device root OID and the system OID are not the same.  The correct
APC rPDU sys OID is 1.3.6.1.4.1.318.1.3.4.6.