### PR TITLE
Store POWER_ON state when performing a REBOOT

### DIFF
--- a/virtualpdu/pdu/__init__.py
+++ b/virtualpdu/pdu/__init__.py
@@ -95,10 +95,10 @@ class PDUOutletControl(PDUOutletFeature):
 
     @value.setter
     def value(self, state):
-        self.core.pdu_outlet_state_changed(
+        self.core.set_pdu_outlet_command(
             pdu=self.pdu_name,
             outlet=self.outlet_number,
-            state=self.states.to_core(state))
+            command=self.states.to_core(state))
 
 
 class PDUOutletState(PDUOutletFeature):

--- a/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
+++ b/virtualpdu/tests/integration/pdu/test_apc_rackpdu.py
@@ -37,7 +37,7 @@ class TestAPCRackPDU(PDUTestCase):
         self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (7,)))
         self.assertEqual(1, self.snmp_get(enterprises + rPDUControl + (8,)))
 
-        self.assertFalse(self.core_mock.pdu_outlet_state_changed.called)
+        self.assertFalse(self.core_mock.set_pdu_outlet_command.called)
 
     def test_port_state_can_be_changed(self):
         enterprises = (1, 3, 6, 1, 4, 1)
@@ -49,8 +49,8 @@ class TestAPCRackPDU(PDUTestCase):
                          self.snmp_get(outlet_1))
 
         self.snmp_set(outlet_1, self.outlet_control_class.states.IMMEDIATE_OFF)
-        self.core_mock.pdu_outlet_state_changed.assert_called_with(
-            pdu=self.pdu.name, outlet=1, state=core.POWER_OFF)
+        self.core_mock.set_pdu_outlet_command.assert_called_with(
+            pdu=self.pdu.name, outlet=1, command=core.POWER_OFF)
 
         self.core_mock.get_pdu_outlet_state.return_value = core.POWER_OFF
         self.assertEqual(self.outlet_control_class.states.IMMEDIATE_OFF,

--- a/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
+++ b/virtualpdu/tests/integration/pdu/test_baytech_mrp27.py
@@ -38,7 +38,7 @@ class TestBaytechMRP27PDU(PDUTestCase):
         self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 9)))
         self.assertEqual(1, self.snmp_get(outlet_state_oid + (1, 10)))
 
-        self.assertFalse(self.core_mock.pdu_outlet_state_changed.called)
+        self.assertFalse(self.core_mock.set_pdu_outlet_command.called)
 
     def test_port_state_can_be_changed(self):
         outlet_state_oid = (1, 3, 6, 1, 4, 1) + (4779, 1, 3, 5, 3, 1, 3)
@@ -49,8 +49,8 @@ class TestBaytechMRP27PDU(PDUTestCase):
                          self.snmp_get(outlet_1))
 
         self.snmp_set(outlet_1, self.outlet_control_class.states.OFF)
-        self.core_mock.pdu_outlet_state_changed.assert_called_with(
-            pdu=self.pdu.name, outlet=1, state=core.POWER_OFF)
+        self.core_mock.set_pdu_outlet_command.assert_called_with(
+            pdu=self.pdu.name, outlet=1, command=core.POWER_OFF)
 
         self.core_mock.get_pdu_outlet_state.return_value = core.POWER_OFF
         self.assertEqual(self.outlet_control_class.states.OFF,

--- a/virtualpdu/tests/integration/test_core_integration.py
+++ b/virtualpdu/tests/integration/test_core_integration.py
@@ -60,7 +60,7 @@ class TestCoreIntegration(base.TestCase):
                                       timeout=1,
                                       retries=1)
 
-    def test_pdu_outlet_state_changed_on_power_off(self):
+    def test_set_pdu_outlet_command_on_power_off(self):
         pdu = apc_rackpdu.APCRackPDU('my_pdu', self.core)
         snmp_client_ = self.get_harness_client(pdu)
 

--- a/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
+++ b/virtualpdu/tests/unit/pdu/base_pdu_test_cases.py
@@ -33,30 +33,30 @@ class BasePDUTests(object):
         outlet_control.value = \
             outlet_control.states.from_core(core.POWER_ON)
 
-        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+        self.core_mock.set_pdu_outlet_command.assert_called_with(
             pdu='my_pdu',
             outlet=1,
-            state=core.POWER_ON)
+            command=core.POWER_ON)
 
     def test_reboot_notifies_core(self):
         outlet_control = self.pdu.oid_mapping[self.outlet_control_oid]
         outlet_control.value = \
             outlet_control.states.from_core(core.REBOOT)
 
-        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+        self.core_mock.set_pdu_outlet_command.assert_called_with(
             pdu='my_pdu',
             outlet=1,
-            state=core.REBOOT)
+            command=core.REBOOT)
 
     def test_power_off_notifies_core(self):
         outlet_control = self.pdu.oid_mapping[self.outlet_control_oid]
         outlet_control.value = \
             outlet_control.states.from_core(core.POWER_OFF)
 
-        self.core_mock.pdu_outlet_state_changed.assert_called_with(
+        self.core_mock.set_pdu_outlet_command.assert_called_with(
             pdu='my_pdu',
             outlet=1,
-            state=core.POWER_OFF)
+            command=core.POWER_OFF)
 
     def test_read_power_on(self):
         outlet_control = self.pdu.oid_mapping[self.outlet_control_oid]

--- a/virtualpdu/tests/unit/test_core.py
+++ b/virtualpdu/tests/unit/test_core.py
@@ -32,35 +32,43 @@ class TestCore(base.TestCase):
         self.core = core.Core(driver=self.driver_mock, mapping=mapping,
                               store=self.store, default_state=core.POWER_ON)
 
-    def test_pdu_outlet_state_changed_on_power_off(self):
-        self.core.pdu_outlet_state_changed(pdu='my_pdu',
-                                           outlet=1,
-                                           state=core.POWER_OFF)
+    def test_set_pdu_outlet_command_on_power_off(self):
+        self.core.set_pdu_outlet_command(pdu='my_pdu',
+                                         outlet=1,
+                                         command=core.POWER_OFF)
         time.sleep(0.1)
         self.driver_mock.power_off.assert_called_with('server_one')
 
-    def test_pdu_outlet_state_changed_machine_not_in_mapping_noop(self):
-        self.core.pdu_outlet_state_changed(pdu='my_pdu',
-                                           outlet=2,
-                                           state=core.POWER_OFF)
+    def test_set_pdu_outlet_command_machine_not_in_mapping_noop(self):
+        self.core.set_pdu_outlet_command(pdu='my_pdu',
+                                         outlet=2,
+                                         command=core.POWER_OFF)
 
         self.assertFalse(self.driver_mock.power_off.called)
         self.assertFalse(self.driver_mock.power_on.called)
 
-    def test_pdu_outlet_state_changed_on_power_on(self):
-        self.core.pdu_outlet_state_changed(pdu='my_pdu',
-                                           outlet=1,
-                                           state=core.POWER_ON)
+    def test_set_pdu_outlet_command_on_power_on(self):
+        self.core.set_pdu_outlet_command(pdu='my_pdu',
+                                         outlet=1,
+                                         command=core.POWER_ON)
         time.sleep(0.1)
         self.driver_mock.power_on.assert_called_with('server_one')
 
-    def test_pdu_outlet_state_changed_on_reboot(self):
-        self.core.pdu_outlet_state_changed(pdu='my_pdu',
-                                           outlet=1,
-                                           state=core.REBOOT)
+    def test_set_pdu_outlet_command_on_reboot(self):
+        self.core.set_pdu_outlet_command(pdu='my_pdu',
+                                         outlet=1,
+                                         command=core.REBOOT)
         time.sleep(0.1)
         self.driver_mock.assert_has_calls([mock.call.power_off('server_one'),
                                            mock.call.power_on('server_one')])
+
+    def test_set_pdu_outlet_command_on_reboot_will_set_state_on(self):
+        self.core.set_pdu_outlet_command(pdu='my_pdu',
+                                         outlet=1,
+                                         command=core.REBOOT)
+        self.assertEqual(
+            core.POWER_ON,
+            self.core.get_pdu_outlet_state(pdu='my_pdu', outlet=1))
 
     def test_pdu_outlet_state_on_cached_state(self):
         self.store[('my_pdu', 1)] = core.POWER_OFF


### PR DESCRIPTION
Before, the outlet command was stored, it was working as expected for
POWER_ON and POWER_OFF but the REBOOT command is not a state. This is
why we introduced a command to state mapping in the core.